### PR TITLE
Fix: Prevent infinite recursion in neural evaluation fallback

### DIFF
--- a/neural.c
+++ b/neural.c
@@ -309,13 +309,13 @@ void shutdown_neural(void) {
 float evaluate_neural(const Board* board) {
 #if HAVE_ONNXRUNTIME
     if (!global_evaluator || !global_evaluator->session) {
-        return evaluate_position(board); // Fall back to basic evaluation
+        return evaluate_basic(board); // Fall back to basic evaluation
     }
     
     // Prepare input tensor
     float input_tensor[BOARD_SIZE * BOARD_SIZE * INPUT_CHANNELS];
     if (!board_to_planes(board, input_tensor, sizeof(input_tensor))) {
-        return evaluate_position(board);
+        return evaluate_basic(board);
     }
     
     // Run neural evaluation
@@ -333,10 +333,10 @@ float evaluate_neural(const Board* board) {
     }
     
     // Fall back to basic evaluation if neural inference fails
-    return evaluate_position(board);
+    return evaluate_basic(board);
 #else
     // Fall back to basic evaluation if ONNX Runtime is not available
-    return evaluate_position(board);
+    return evaluate_basic(board);
 #endif
 }
 


### PR DESCRIPTION
The `evaluate_neural` function previously called `evaluate_position` as a fallback mechanism when the neural network evaluation could not be performed (e.g., ONNX runtime unavailable, model not loaded, or inference error). If `current_eval_type` remained `EVAL_NEURAL`, this would lead to an infinite recursion and a stack overflow.

This commit changes the fallback call in `evaluate_neural` to `evaluate_basic` directly. This ensures that if neural evaluation fails, the system gracefully degrades to using the basic evaluation function, allowing the search to complete and preventing a crash.

The related `is_quiet_neural` function, which currently defers to `is_quiet_basic`, was reviewed and deemed acceptable for the current scope, as it doesn't contribute to the recursion issue.