### PR TITLE
fix: Handle all enum cases in quiescence search switch

### DIFF
--- a/search.c
+++ b/search.c
@@ -239,8 +239,12 @@ float quiescence_search(Board *board, float alpha, float beta, uint64_t *nodes, 
                     case BISHOP: captured_piece_value = BISHOP_VALUE; break;
                     case ROOK: captured_piece_value = ROOK_VALUE; break;
                     case QUEEN: captured_piece_value = QUEEN_VALUE; break;
-                    // No default case needed as captured_piece_value remains 0 for unknown types,
-                    // which means the pruning condition would be based on stand_pat + 0 + margin < alpha.
+                    case KING:  // Kings should not be capturable in a way that reaches here in quiescence,
+                                // but handle for completeness to avoid warnings.
+                    case EMPTY: // Should not happen for a victim piece in a capture move.
+                    default:    // Catch any other unexpected piece types.
+                        captured_piece_value = 0; // Assign 0 for safety / to prevent uninitialized use.
+                        break;
                 }
 
                 if (stand_pat + captured_piece_value + DELTA_PRUNING_MARGIN < alpha) {


### PR DESCRIPTION
Addresses a compiler warning (-Wswitch) in the `quiescence_search` function in `search.c`. The switch statement for `victim_type` (used in delta pruning) did not explicitly handle all `PieceType` enum values.

Added `case KING:`, `case EMPTY:`, and a `default:` case to the switch. All these cases correctly set `captured_piece_value` to 0. Comments were updated to reflect these changes.

This makes the switch statement exhaustive and prevents the compiler warning.