### PR TITLE
Fix printf warnings for uint64_t

### DIFF
--- a/main.c
+++ b/main.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <inttypes.h>
 #include <time.h>
 #include "board.h"
 #include "movegen.h"
@@ -299,7 +300,7 @@ void play_against_computer(int depth) {
             Board current_board = board;  // Copy current board for search
             Move computer_move;
             float score_pawn_units = find_best_move(&current_board, search_depth, &computer_move, &nodes, 1);
-            printf("Computer move: %s (score: %.2f, nodes: %llu)\n", move_to_string(computer_move), score_pawn_units, nodes);
+            printf("Computer move: %s (score: %.2f, nodes: %" PRIu64 ")\n", move_to_string(computer_move), score_pawn_units, nodes);
 
             make_move(&board, &computer_move);
         }

--- a/search.c
+++ b/search.c
@@ -4,6 +4,7 @@
 #include "board.h"
 #include <stdio.h>
 #include <time.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 #include <float.h>
@@ -327,7 +328,7 @@ float find_best_move(Board *board, int depth, Move *best_move, uint64_t *nodes, 
             }
 
             if (verbosity > 0) {
-                printf("info depth %d score cp %.0f nodes %llu pv ", depth, uci_score_cp, *nodes);
+                printf("info depth %d score cp %.0f nodes %" PRIu64 " pv ", depth, uci_score_cp, *nodes);
                 Board temp_board_for_san = original_board_state_at_root;
                 for (int k = 0; k < overall_best_pv_length; k++) {
                     char san_buffer[10];


### PR DESCRIPTION
Replaced %llu with the PRIu64 macro from inttypes.h to correctly format uint64_t values in printf statements. This resolves compiler warnings related to mismatched format specifiers on different platforms.

Affected files:
- main.c
- search.c